### PR TITLE
$httpOptions for \GuzzleHttp\Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ $gql = $builder->getQuery();
 # Constructing The Client
 
 A Client object can easily be instantiated by providing the GraphQL endpoint
-URL. The Client constructor also receives an optional "authorizationHeaders"
+URL. 
+
+The Client constructor also receives an optional "authorizationHeaders"
 array, which can be used to add authorization headers to all requests being sent
 to the GraphQL server.
 
@@ -233,6 +235,33 @@ Example:
 $client = new Client(
     'http://api.graphql.com',
     ['Authorization' => 'Basic xyz']
+);
+```
+
+
+The Client constructor also receives an optional "httpOptions" array, which can be used to add custom [Guzzle HTTP Client request options](https://guzzle.readthedocs.io/en/latest/request-options.html).
+
+Example:
+
+```
+$client = new Client(
+    'http://api.graphql.com',
+    [],
+    [ 
+        'connect_timeout' => 5,
+        'timeout' => 5,
+        'headers' => [
+            'Authorization' => 'Basic xyz'
+            'User-Agent' => 'testing/1.0',
+        ],
+        'proxy' => [
+                'http'  => 'tcp://localhost:8125', // Use this proxy with "http"
+                'https' => 'tcp://localhost:9124', // Use this proxy with "https",
+                'no' => ['.mit.edu', 'foo.com']    // Don't use a proxy with these
+        ],
+        'cert' => ['/path/server.pem', 'password']
+        ...
+    ]
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ $client = new Client(
 ```
 
 
-The Client constructor also receives an optional "httpOptions" array, which can be used to add custom [Guzzle HTTP Client request options](https://guzzle.readthedocs.io/en/latest/request-options.html).
+The Client constructor also receives an optional "httpOptions" array, which **overrides** the "authorizationHeaders" and can be used to add custom [Guzzle HTTP Client request options](https://guzzle.readthedocs.io/en/latest/request-options.html).
 
 Example:
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,16 +30,24 @@ class Client
     protected $httpClient;
 
     /**
+     * @var array
+     */
+    protected $httpOptions;
+
+
+    /**
      * Client constructor.
      *
      * @param string $endpointUrl
-     * @param array  $authorizationHeaders
+     * @param array $authorizationHeaders
+     * @param array $httpOptions
      */
-    public function __construct(string $endpointUrl, array $authorizationHeaders = [])
+    public function __construct(string $endpointUrl, array $authorizationHeaders = [], array $httpOptions = [])
     {
         $this->endpointUrl          = $endpointUrl;
         $this->authorizationHeaders = $authorizationHeaders;
         $this->httpClient           = new \GuzzleHttp\Client();
+        $this->httpOptions          = $httpOptions;
     }
 
     /**
@@ -77,6 +85,12 @@ class Client
         if (!empty($this->authorizationHeaders)) {
             $options['headers'] = $this->authorizationHeaders;
         }
+
+        // Set request options for \GuzzleHttp\Client
+        if (!empty($this->httpOptions)) {
+            $options = $this->httpOptions;
+        }
+
         $options['headers']['Content-Type'] = 'application/json';
 
         // Convert empty variables array to empty json object

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -89,14 +89,12 @@ class ClientTest extends TestCase
         $secondRequest = $container[2]['request'];
         $this->assertEquals('{"query":"query_string","variables":{"name":"val"}}', $secondRequest->getBody()->getContents());
 
-
         /** @var Request $fourthRequest */
         $fourthRequest = $container[3]['request'];
-        $this->assertNotNull($fourthRequest->getHeader('Authorization'));
+        $this->assertNotEmpty($fourthRequest->getHeader('Authorization'));
         $this->assertNotEmpty($fourthRequest->getHeader('User-Agent'));
         $this->assertEquals(['Basic zyx'], $fourthRequest->getHeader('Authorization'));
         $this->assertEquals(['test'], $fourthRequest->getHeader('User-Agent'));
-
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -70,7 +70,7 @@ class ClientTest extends TestCase
         $client = new MockClient('', $handler);
         $client->runRawQuery('query_string',  false, ['name' => 'val']);
 
-        $client = new MockClient('', $handler, [], ['headers' => [ 'Authorization' => 'Basic xyz', 'User-Agent' => 'test' ]]);
+        $client = new MockClient('', $handler, ['Authorization' => 'Basic xyz'], ['headers' => [ 'Authorization' => 'Basic zyx', 'User-Agent' => 'test' ]]);
         $client->runRawQuery('query_string');
 
         /** @var Request $firstRequest */
@@ -94,7 +94,7 @@ class ClientTest extends TestCase
         $fourthRequest = $container[3]['request'];
         $this->assertNotNull($fourthRequest->getHeader('Authorization'));
         $this->assertNotEmpty($fourthRequest->getHeader('User-Agent'));
-        $this->assertEquals(['Basic xyz'], $fourthRequest->getHeader('Authorization'));
+        $this->assertEquals(['Basic zyx'], $fourthRequest->getHeader('Authorization'));
         $this->assertEquals(['test'], $fourthRequest->getHeader('User-Agent'));
 
     }

--- a/tests/MockClient.php
+++ b/tests/MockClient.php
@@ -16,11 +16,12 @@ class MockClient extends Client
      *
      * @param string $endpointUrl
      * @param object $handler
-     * @param array  $authorizationHeaders
+     * @param array $authorizationHeaders
+     * @param array $httpOptions
      */
-    public function __construct(string $endpointUrl, $handler, array $authorizationHeaders = [])
+    public function __construct(string $endpointUrl, $handler, array $authorizationHeaders = [], array $httpOptions = [])
     {
-        parent::__construct($endpointUrl, $authorizationHeaders);
+        parent::__construct($endpointUrl, $authorizationHeaders, $httpOptions);
         $this->httpClient = new \GuzzleHttp\Client(['handler' => $handler]);
     }
 }


### PR DESCRIPTION
https://github.com/mghoneimy/php-graphql-client/pull/12#issuecomment-526716335

```
$client = new Client(
    'http://api.graphql.com',
    [],
    [ 
        'connect_timeout' => 5,
        'timeout' => 5,
        'headers' => [
            'Authorization' => 'Basic xyz'
            'User-Agent' => 'testing/1.0',
        ],
        'proxy' => [
                'http'  => 'tcp://localhost:8125', // Use this proxy with "http"
                'https' => 'tcp://localhost:9124', // Use this proxy with "https",
                'no' => ['.mit.edu', 'foo.com']    // Don't use a proxy with these
        ],
        'cert' => ['/path/server.pem', 'password']
        ...
    ]
);
```