### PR TITLE
Support aliases for selection set and arguments for scalar selected fields.

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -211,7 +211,7 @@ class Query extends NestableObject
     {
         $queryFormat = static::QUERY_FORMAT;
         if (!$this->isNested && $this->fieldName !== static::OPERATION_TYPE) {
-            $queryFormat = $this->generateSignature() . " {\n" . static::QUERY_FORMAT . "\n}";
+            $queryFormat = $this->generateSignature() . " {" . PHP_EOL . static::QUERY_FORMAT . PHP_EOL. "}";
         }
         $argumentsString    = $this->constructArguments();
         $selectionSetString = $this->constructSelectionSet();

--- a/src/QueryBuilder/AbstractQueryBuilder.php
+++ b/src/QueryBuilder/AbstractQueryBuilder.php
@@ -74,9 +74,11 @@ abstract class AbstractQueryBuilder implements QueryBuilderInterface
     /**
      * @param string|QueryBuilder|Query $selectedField
      *
+     * @param string|null $alias
+     * @param array $arguments
      * @return $this
      */
-    protected function selectField($selectedField)
+    protected function selectField($selectedField, string $alias = null, array $arguments = [])
     {
         if (
             is_string($selectedField)
@@ -84,6 +86,21 @@ abstract class AbstractQueryBuilder implements QueryBuilderInterface
             || $selectedField instanceof Query
             || $selectedField instanceof InlineFragment
         ) {
+
+            // Set an alias for selectedField
+            $selectedField = ($alias) ? $alias .':'. $selectedField : $selectedField;
+
+            // Add arguments for selectedField
+            if (is_array($arguments) && count($arguments)) {
+
+                $params = '';
+                foreach ($arguments as $k => $v) {
+                    $params.= " $k : \"$v\" ";
+                }
+                $selectedField .= " ($params)";
+            }
+
+
             $this->selectionSet[] = $selectedField;
         }
 

--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -16,11 +16,13 @@ class QueryBuilder extends AbstractQueryBuilder
      *
      * @param Query|QueryBuilder|string $selectedField
      *
+     * @param string|null $alias
+     * @param array $arguments
      * @return AbstractQueryBuilder|QueryBuilder
      */
-    public function selectField($selectedField)
+    public function selectField($selectedField, string $alias = null, array $arguments = [])
     {
-        return parent::selectField($selectedField);
+        return parent::selectField($selectedField, $alias, $arguments);
     }
 
     /**

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -61,6 +61,75 @@ field_one
         $this->queryBuilder->getQuery();
     }
 
+
+    /**
+     * @covers \GraphQL\QueryBuilder\QueryBuilder::__construct
+     * @covers \GraphQL\QueryBuilder\AbstractQueryBuilder::__construct
+     */
+    public function testSelectFieldAlias()
+    {
+        $builder = new QueryBuilder('Object');
+        $builder->selectField('field_one', 'fieldAlias');
+        $this->assertEquals(
+            'query {
+Object {
+fieldAlias:field_one
+}
+}',
+            (string) $builder->getQuery()
+        );
+    }
+
+    /**
+     * @covers \GraphQL\QueryBuilder\QueryBuilder::__construct
+     * @covers \GraphQL\QueryBuilder\AbstractQueryBuilder::__construct
+     */
+    public function testSelectFieldAliasWithArguments()
+    {
+        $builder = new QueryBuilder('Object');
+        $builder->selectField('field_one', 'fieldAlias', ['param1' => 'val1', 'param2' => 'val2' ]);
+        $this->assertEquals(
+            'query {
+Object {
+fieldAlias:field_one ( param1 : "val1"  param2 : "val2" )
+}
+}',
+            (string) $builder->getQuery()
+        );
+
+    }
+
+    /**
+     * @covers \GraphQL\QueryBuilder\QueryBuilder::__construct
+     * @covers \GraphQL\QueryBuilder\AbstractQueryBuilder::__construct
+     */
+    public function testSelectionSetAliasWithArguments()
+    {
+        $builder = new QueryBuilder('Object');
+
+        $builder->selectField(
+            (new Query('data'))->setArguments(['some_field' => 'params'])
+                ->setSelectionSet(
+                    [
+                        'aliasId:first_field' => ['param1' => 'val1', 'param2' => 'val2' ],
+                        'second_field' => ['param1' => 'val1', 'param2' => 'val2' ]
+                    ])
+        );
+
+        $this->assertEquals(
+            'query {
+Object {
+data(some_field: "params") {
+   aliasId:first_field ( param1 : "val1"  param2 : "val2" )
+   second_field ( param1 : "val1"  param2 : "val2" )
+}
+}
+}',
+            (string) $builder->getQuery()
+        );
+
+
+    }
     /**
      * @covers \GraphQL\QueryBuilder\QueryBuilder::setVariable
      * @covers \GraphQL\QueryBuilder\AbstractQueryBuilder::setVariable


### PR DESCRIPTION
https://github.com/mghoneimy/php-graphql-oqm/issues/1#issuecomment-526711660

**The ability to set arguments for scalar selected fields.**

```php
selectField($selectedField, string $alias = null, array $arguments = [])
```

Example:

```php
selectField('field_one', 'fieldAlias', ['param1' => 'val1', 'param2' => 'val2' ]);
```

**Support aliases and arguments for selection set.**

```php
setSelectionSet(array $selectionSet)
```

Example:
```php
setSelectionSet([
             'aliasId:first_field' => ['param1' => 'val1', 'param2' => 'val2' ],
             'second_field' => ['param1' => 'val1', 'param2' => 'val2' ]
        ])
```

fix: pass tests on windows PHP_EOL.