### PR TITLE
Win tests

### DIFF
--- a/src/FieldTrait.php
+++ b/src/FieldTrait.php
@@ -40,7 +40,7 @@ trait FieldTrait
      */
     protected function constructSelectionSet(): string
     {
-        $attributesString = " {\n";
+        $attributesString = " {" . PHP_EOL;
         $first            = true;
         foreach ($this->selectionSet as $attribute) {
 
@@ -48,7 +48,7 @@ trait FieldTrait
             if ($first) {
                 $first = false;
             } else {
-                $attributesString .= "\n";
+                $attributesString .= PHP_EOL;
             }
 
             // If query is included in attributes set as a nested query
@@ -59,7 +59,7 @@ trait FieldTrait
             // Append attribute to returned attributes list
             $attributesString .= $attribute;
         }
-        $attributesString .= "\n}";
+        $attributesString .= PHP_EOL . "}";
 
         return $attributesString;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -211,7 +211,7 @@ class Query extends NestableObject
     {
         $queryFormat = static::QUERY_FORMAT;
         if (!$this->isNested && $this->fieldName !== static::OPERATION_TYPE) {
-            $queryFormat = $this->generateSignature() . " {\n" . static::QUERY_FORMAT . "\n}";
+            $queryFormat = $this->generateSignature() . " {" . PHP_EOL . static::QUERY_FORMAT . PHP_EOL . "}";
         }
         $argumentsString    = $this->constructArguments();
         $selectionSetString = $this->constructSelectionSet();


### PR DESCRIPTION
**The test results on win7 x64 PHP 7.3.9 MINGW64**

<details>
  <summary>vendor/phpunit/phpunit/phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xml</summary>

```
$ vendor/phpunit/phpunit/phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xm
PHPUnit 7.5.15 by Sebastian Bergmann and contributors.

Error:         No code coverage driver is available

...........FFFFFFF.FFFFFFFF...FFS.FSFSF.FFFFFFFSSSSSSSSS......... 65 / 70 ( 92%)
.....                                                             70 / 70 (100%)

Time: 184 ms, Memory: 6.00 MB

There were 27 failures:

1) GraphQL\Tests\InlineFragmentTest::testConvertToString
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'... on Test {\r\n
-field1\r\n
-field2\r\n
+'... on Test {\n
+field1\n
+field2\n
 }'

X:\php-graphql-client\tests\InlineFragmentTest.php:37

2) GraphQL\Tests\InlineFragmentTest::testConvertNestedFragmentToString
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'... on Test {\r\n
-field1\r\n
-field2\r\n
-sub_field(first: 5) {\r\n
-sub_field3\r\n
-... on Nested {\r\n
-another_field\r\n
-}\r\n
-}\r\n
+'... on Test {\n
+field1\n
+field2\n
+sub_field(first: 5) {\n
+sub_field3\n
+... on Nested {\n
+another_field\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\InlineFragmentTest.php:84

3) GraphQL\Tests\MutationTest::testMutationWithoutOperationType
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'mutation {\r\n
-createObject\r\n
+'mutation {\n
+createObject\n
 }'

X:\php-graphql-client\tests\MutationTest.php:21

4) GraphQL\Tests\MutationTest::testMutationWithoutSelectedFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'mutation {\r\n
-createObject(name: "TestObject" type: "TestType")\r\n
+'mutation {\n
+createObject(name: "TestObject" type: "TestType")\n
 }'

X:\php-graphql-client\tests\MutationTest.php:51

5) GraphQL\Tests\MutationTest::testMutationWithFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'mutation {\r\n
-createObject {\r\n
-fieldOne\r\n
-fieldTwo\r\n
-}\r\n
+'mutation {\n
+createObject {\n
+fieldOne\n
+fieldTwo\n
+}\n
 }'

X:\php-graphql-client\tests\MutationTest.php:74

6) GraphQL\Tests\MutationTest::testMutationWithArgumentsAndFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'mutation {\r\n
-createObject(argOne: 1 argTwo: "val") {\r\n
-fieldOne\r\n
-fieldTwo\r\n
-}\r\n
+'mutation {\n
+createObject(argOne: 1 argTwo: "val") {\n
+fieldOne\n
+fieldTwo\n
+}\n
 }'

X:\php-graphql-client\tests\MutationTest.php:103

7) GraphQL\Tests\QueryBuilderTest::testConstruct
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object {\r\n
-field_one\r\n
-}\r\n
+'query {\n
+Object {\n
+field_one\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:49

8) GraphQL\Tests\QueryBuilderTest::testAddVariables
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query($var: String $intVar: Int=4) {\r\n
-Object {\r\n
-fieldOne\r\n
-}\r\n
+'query($var: String $intVar: Int=4) {\n
+Object {\n
+fieldOne\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:81

9) GraphQL\Tests\QueryBuilderTest::testAddVariablesToSecondLevelQueryDoesNothing
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query($var: String) {\r\n
-Object {\r\n
-fieldOne\r\n
-Nested {\r\n
-fieldTwo\r\n
-}\r\n
-}\r\n
+'query($var: String) {\n
+Object {\n
+fieldOne\n
+Nested {\n
+fieldTwo\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:107

10) GraphQL\Tests\QueryBuilderTest::testSelectScalarFields
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object {\r\n
-field_one\r\n
-field_two\r\n
-}\r\n
+'query {\n
+Object {\n
+field_one\n
+field_two\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:127

11) GraphQL\Tests\QueryBuilderTest::testSelectNestedQuery
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object {\r\n
-Nested {\r\n
-some_field\r\n
-}\r\n
-}\r\n
+'query {\n
+Object {\n
+Nested {\n
+some_field\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:149

12) GraphQL\Tests\QueryBuilderTest::testSelectNestedQueryBuilder
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object {\r\n
-Nested {\r\n
-some_field\r\n
-}\r\n
-}\r\n
+'query {\n
+Object {\n
+Nested {\n
+some_field\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:171

13) GraphQL\Tests\QueryBuilderTest::testSelectInlineFragment
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object {\r\n
-... on Type {\r\n
-field\r\n
-}\r\n
-}\r\n
+'query {\n
+Object {\n
+... on Type {\n
+field\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:194

14) GraphQL\Tests\QueryBuilderTest::testSelectArguments
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(str_arg: "value") {\r\n
-field\r\n
-}\r\n
+'query {\n
+Object(str_arg: "value") {\n
+field\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:213

15) GraphQL\Tests\QueryBuilderTest::testSetTwoLevelArguments
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(outer_arg: "outer val") {\r\n
-Nested(nested_arg: [1, 2, 3]) {\r\n
-some_field\r\n
-another_field\r\n
-}\r\n
-}\r\n
+'query {\n
+Object(outer_arg: "outer val") {\n
+Nested(nested_arg: [1, 2, 3]) {\n
+some_field\n
+another_field\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\QueryBuilderTest.php:282

16) GraphQL\Tests\QueryTest::testQueryWithOperationType
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-\r\n
+'query {\n
+\n
 }'

X:\php-graphql-client\tests\QueryTest.php:60

17) GraphQL\Tests\QueryTest::testQueryWithOperationName
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query retrieveObject {\r\n
-Object {\r\n
-\r\n
-}\r\n
+'query retrieveObject {\n
+Object {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:96

18) GraphQL\Tests\QueryTest::testQueryWithOneVariable
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query($var: String) {\r\n
-Object {\r\n
-\r\n
-}\r\n
+'query($var: String) {\n
+Object {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:167

19) GraphQL\Tests\QueryTest::testQueryWithVariablesInSecondLevelDoesNothing
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query($var: String $intVar: Int=4) {\r\n
-Object {\r\n
-Nested {\r\n
-\r\n
-}\r\n
-}\r\n
+'query($var: String $intVar: Int=4) {\n
+Object {\n
+Nested {\n
+\n
+}\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:212

20) GraphQL\Tests\QueryTest::testEmptyQuery
Incorrect empty query string
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object {\r\n
-\r\n
-}\r\n
+'query {\n
+Object {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:256

21) GraphQL\Tests\QueryTest::testStringArgumentValue
Query has improperly formatted parameter list
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(arg1: "value") {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(arg1: "value") {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:300

22) GraphQL\Tests\QueryTest::testIntegerArgumentValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(arg1: 23) {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(arg1: 23) {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:325

23) GraphQL\Tests\QueryTest::testBooleanArgumentValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(arg1: true) {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(arg1: true) {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:350

24) GraphQL\Tests\QueryTest::testNullArgumentValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(arg1: null) {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(arg1: null) {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:375

25) GraphQL\Tests\QueryTest::testArrayIntegerArgumentValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(arg1: [1, 2, 3]) {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(arg1: [1, 2, 3]) {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:400

26) GraphQL\Tests\QueryTest::testJsonObjectArgumentValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(obj: {json_string_array: ["json value"]}) {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(obj: {json_string_array: ["json value"]}) {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:426

27) GraphQL\Tests\QueryTest::testArrayStringArgumentValue
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'query {\r\n
-Object(arg1: ["one", "two", "three"]) {\r\n
-\r\n
-}\r\n
+'query {\n
+Object(arg1: ["one", "two", "three"]) {\n
+\n
+}\n
 }'

X:\php-graphql-client\tests\QueryTest.php:451

FAILURES!
Tests: 70, Assertions: 94, Failures: 27, Skipped: 12.


```
</details>


**Tests with this PR on win7 x64 PHP 7.3.9 MINGW64**

```vendor/phpunit/phpunit/phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xml
PHPUnit 7.5.15 by Sebastian Bergmann and contributors.

Error:         No code coverage driver is available

................................................................. 65 / 70 ( 92%)
.....                                                             70 / 70 (100%)

Time: 157 ms, Memory: 6.00 MB

OK (70 tests, 111 assertions)
```