### PR TITLE
Fix multi-line strings

### DIFF
--- a/src/Util/StringLiteralFormatter.php
+++ b/src/Util/StringLiteralFormatter.php
@@ -22,7 +22,11 @@ class StringLiteralFormatter
             // Do not treat value as a string if it starts with '$', which indicates that it's a variable name
             if (strpos($value, '$') !== 0) {
                 $value = str_replace('"', '\"', $value);
-                $value = "\"$value\"";
+                if (strpos($value, "\n") !== false) {
+                    $value = '"""' . $value . '"""';
+                } else {
+                    $value = "\"$value\"";
+                }
             }
         } elseif (is_bool($value)) {
             if ($value) {

--- a/tests/StringLiteralFormatterTest.php
+++ b/tests/StringLiteralFormatterTest.php
@@ -37,6 +37,9 @@ class StringLiteralFormatterTest extends TestCase
         $formattedString = StringLiteralFormatter::formatValueForRHS('\'singleQuotes\'');
         $this->assertEquals('"\'singleQuotes\'"', $formattedString);
 
+        $formattedString = StringLiteralFormatter::formatValueForRHS("with \n newlines");
+        $this->assertEquals("\"\"\"with \n newlines\"\"\"", $formattedString);
+
         // Integer tests
         $integerString = StringLiteralFormatter::formatValueForRHS(25);
         $this->assertEquals('25', $integerString);


### PR DESCRIPTION
If a string contains a newline character, a unterminated string error will occur, this fixes that by enclosing in triple quotes