### PR TITLE
Pass request and response to Results object to allow the result or th…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -136,6 +136,6 @@ class Client
         }
 
         // Parse response to extract results
-        return new Results($response, $resultsAsArray);
+        return new Results($request, $response, $resultsAsArray);
     }
 }

--- a/src/Exception/QueryError.php
+++ b/src/Exception/QueryError.php
@@ -3,6 +3,8 @@
 namespace GraphQL\Exception;
 
 use RuntimeException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * This exception is triggered when the GraphQL endpoint returns an error in the provided query
@@ -19,13 +21,27 @@ class QueryError extends RuntimeException
     protected $errorDetails;
 
     /**
+     * @var RequestInterface
+     */
+    protected $requestObject;
+
+    /**
+     * @var ResponseInterface
+     */
+    protected $responseObject;
+
+    /**
      * QueryError constructor.
      *
      * @param array $errorDetails
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
      */
-    public function __construct($errorDetails)
+    public function __construct($errorDetails, $request, $response)
     {
         $this->errorDetails = $errorDetails['errors'][0];
+        $this->requestObject = $request;
+        $this->responseObject = $response;
         parent::__construct($this->errorDetails['message']);
     }
 
@@ -35,5 +51,21 @@ class QueryError extends RuntimeException
     public function getErrorDetails()
     {
         return $this->errorDetails;
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getRequestObject()
+    {
+        return $this->requestObject;
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getResponseObject()
+    {
+        return $this->responseObject;
     }
 }

--- a/src/Results.php
+++ b/src/Results.php
@@ -3,6 +3,7 @@
 namespace GraphQL;
 
 use GraphQL\Exception\QueryError;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -16,6 +17,11 @@ class Results
      * @var string
      */
     protected $responseBody;
+
+    /**
+     * @var RequestInterface
+     */
+    protected $requestObject;
 
     /**
      * @var ResponseInterface
@@ -32,13 +38,15 @@ class Results
      *
      * Receives json response from GraphQL api response and parses it as associative array or nested object accordingly
      *
+     * @param RequestInterface  $request
      * @param ResponseInterface $response
      * @param bool              $asArray
      *
      * @throws QueryError
      */
-    public function __construct(ResponseInterface $response, $asArray = false)
+    public function __construct(RequestInterface $request, ResponseInterface $response, $asArray = false)
     {
+        $this->requestObject  = $request;
         $this->responseObject = $response;
         $this->responseBody   = $this->responseObject->getBody()->getContents();
         $this->results        = json_decode($this->responseBody, $asArray);
@@ -51,7 +59,7 @@ class Results
 
             // Reformat results to an array and use it to initialize exception object
             $this->reformatResults(true);
-            throw new QueryError($this->results);
+            throw new QueryError($this->results, $request, $response);
         }
     }
 
@@ -101,5 +109,21 @@ class Results
     public function getResponseObject()
     {
         return $this->responseObject;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRequestBody()
+    {
+        return $this->requestObject->getBody()->__toString();
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getRequestObject()
+    {
+        return $this->requestObject;
     }
 }

--- a/tests/QueryErrorTest.php
+++ b/tests/QueryErrorTest.php
@@ -3,6 +3,10 @@
 namespace GraphQL\Tests;
 
 use GraphQL\Exception\QueryError;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -12,6 +16,25 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryErrorTest extends TestCase
 {
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var MockHandler
+     */
+    protected $mockHandler;
+
+    /**
+     *
+     */
+    protected function setUp(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $this->client      = new Client(['handler' => $this->mockHandler]);
+    }
+
     /**
      * @covers \GraphQL\Exception\QueryError::__construct
      * @covers \GraphQL\Exception\QueryError::getErrorDetails
@@ -33,7 +56,9 @@ class QueryErrorTest extends TestCase
             ]
         ];
 
-        $queryError = new QueryError($errorData);
+        $request = new Request('POST', '');
+        $response = $this->client->post('', []);
+        $queryError = new QueryError($errorData, $request, $response);
         $this->assertEquals($exceptionMessage, $queryError->getMessage());
         $this->assertEquals(
             [

--- a/tests/ResultsTest.php
+++ b/tests/ResultsTest.php
@@ -6,6 +6,7 @@ use GraphQL\Exception\QueryError;
 use GraphQL\Results;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -60,8 +61,9 @@ class ResultsTest extends TestCase
         $response = new Response(200, [], $body);
         $this->mockHandler->append($response);
 
+        $request = new Request('POST', '');
         $response = $this->client->post('', []);
-        $results  = new Results($response);
+        $results  = new Results($request, $response);
 
         $this->assertEquals($response, $results->getResponseObject());
         $this->assertEquals($body, $results->getResponseBody());
@@ -107,8 +109,9 @@ class ResultsTest extends TestCase
         $originalResponse = new Response(200, [], $body);
         $this->mockHandler->append($originalResponse);
 
+        $request = new Request('POST', '');
         $response = $this->client->post('', []);
-        $results  = new Results($response, true);
+        $results  = new Results($request, $response, true);
 
         $this->assertEquals($originalResponse, $results->getResponseObject());
         $this->assertEquals($body, $results->getResponseBody());
@@ -163,9 +166,10 @@ class ResultsTest extends TestCase
         $originalResponse = new Response(200, [], $body);
         $this->mockHandler->append($originalResponse);
 
+        $request = new Request('POST', '');
         $response = $this->client->post('', []);
         $this->expectException(QueryError::class);
-        new Results($response);
+        new Results($request, $response);
     }
 
     /**
@@ -193,8 +197,9 @@ class ResultsTest extends TestCase
         $originalResponse = new Response(200, [], $body);
         $this->mockHandler->append($originalResponse);
 
+        $request = new Request('POST', '');
         $response = $this->client->post('', []);
-        $results  = new Results($response);
+        $results  = new Results($request, $response);
         $results->reformatResults(true);
 
         $this->assertEquals(
@@ -252,8 +257,9 @@ class ResultsTest extends TestCase
         $originalResponse = new Response(200, [], $body);
         $this->mockHandler->append($originalResponse);
 
+        $request = new Request('POST', '');
         $response = $this->client->post('', []);
-        $results  = new Results($response, true);
+        $results  = new Results($request, $response, true);
         $results->reformatResults(false);
 
         $object = new stdClass();


### PR DESCRIPTION
Pass request and response to Results object to allow the result or the QueryError that may be generated to provide access to those objects for debugging or other purposes.

When a QueryError exception is raised to code, there is no way to see the body or other detail of the request or response of the transaction.

This patch adds a getRequestObject() and getResponseObject() to the QueryError exception, and adds getRequestBody() and getRequestObject() methods to the Results object
