### PR TITLE
Support guzzlehttp/psr7 2+, remove support for guzzlehttp/psr7 < 1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "phpunit/phpunit": "^7.5|^8.0",
         "codacy/coverage": "^1.4"
     },
+    "conflict": {
+        "guzzlehttp/psr7": "< 1.7.0"
+    },
     "scripts": {
         "test": "phpunit tests/ --whitelist src/ --coverage-clover build/coverage/xml"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,8 +7,8 @@ use GraphQL\Exception\MethodNotSupportedException;
 use GraphQL\QueryBuilder\QueryBuilderInterface;
 use GraphQL\Util\GuzzleAdapter;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Client\ClientInterface;
 use TypeError;
 
@@ -119,7 +119,7 @@ class Client
         if (empty($variables)) $variables = (object) null;
         // Set query in the request body
         $bodyArray = ['query' => (string) $queryString, 'variables' => $variables];
-        $request = $request->withBody(Psr7\stream_for(json_encode($bodyArray)));
+        $request = $request->withBody(Utils::streamFor(json_encode($bodyArray)));
 
         // Send api request and get response
         try {


### PR DESCRIPTION
This change replaces a deprecated function from guzzlehttp/psr7. It was deprecated in guzzlehttp/psr7 1.7.0 and removed in guzzlehttp/psr7 2.0.

Currently, php-graphql-client does not block guzzlehttp/psr7 2.0, so installations using php-graphql-client will crash when guzzlehttp/psr7 is updated to the latest version.