### PR TITLE
Cast the stream to string instead of getting the contents

### DIFF
--- a/src/Results.php
+++ b/src/Results.php
@@ -40,7 +40,7 @@ class Results
     public function __construct(ResponseInterface $response, $asArray = false)
     {
         $this->responseObject = $response;
-        $this->responseBody   = $this->responseObject->getBody()->getContents();
+        $this->responseBody   = (string) $this->responseObject->getBody();
         $this->results        = json_decode($this->responseBody, $asArray);
 
         // Check if any errors exist, and throw exception if they do

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -79,7 +79,7 @@ class ClientTest extends TestCase
 
         /** @var Request $firstRequest */
         $firstRequest = $container[0]['request'];
-        $this->assertEquals('{"query":"query_string","variables":{}}', $firstRequest->getBody()->getContents());
+        $this->assertEquals('{"query":"query_string","variables":{}}', (string) $firstRequest->getBody());
         $this->assertSame('POST', $firstRequest->getMethod());
 
         /** @var Request $thirdRequest */
@@ -92,7 +92,7 @@ class ClientTest extends TestCase
 
         /** @var Request $secondRequest */
         $secondRequest = $container[2]['request'];
-        $this->assertEquals('{"query":"query_string","variables":{"name":"val"}}', $secondRequest->getBody()->getContents());
+        $this->assertEquals('{"query":"query_string","variables":{"name":"val"}}', (string) $secondRequest->getBody());
 
         /** @var Request $fourthRequest */
         $fourthRequest = $container[3]['request'];


### PR DESCRIPTION
PHP FIG PSR-7 describes getContents as "Returns the *remaining* contents in a string", while the interface description mentions "[...] including serialization of the entire stream to a string.".
For some implementations of PSR-7 the stream is not rewinded and thus getContents turns out to be an empty string in some cases. Also see https://github.com/php-fig/http-message/blob/efd67d1dc14a7ef4fc4e518e7dee91c271d524e4/src/StreamInterface.php#L136-L143 and https://github.com/Nyholm/psr7/issues/135#issuecomment-546593859.