### PR TITLE
allow http-message ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "ext-json": "*",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0 ",
         "psr/http-client": "^1.0",
         "guzzlehttp/guzzle": "^6.3|^7.0.1"
     },


### PR DESCRIPTION
This pull request allows psr/http-message ^2.0 as well as ^1.0. There are no breaking changes in this version, just the inclusion of types.