### PR TITLE
Make it possible to get arguments and field name

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -92,6 +92,9 @@ class Query extends NestableObject
         $this->isNested      = false;
     }
 
+    /**
+     * @return string
+     */
     public function getFieldName(): string
     {
         return $this->fieldName;
@@ -168,6 +171,9 @@ class Query extends NestableObject
         return $this;
     }
 
+    /**
+     * @return array
+     */
     public function getArguments(): array
     {
         return $this->arguments;

--- a/src/Query.php
+++ b/src/Query.php
@@ -92,6 +92,11 @@ class Query extends NestableObject
         $this->isNested      = false;
     }
 
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+
     /**
      * @param string $alias
      *
@@ -161,6 +166,11 @@ class Query extends NestableObject
         $this->arguments = $arguments;
 
         return $this;
+    }
+
+    public function getArguments(): array
+    {
+        return $this->arguments;
     }
 
     /**

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -785,7 +785,7 @@ things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
             ]);
         $sets = $gql->getSelectionSet();
         foreach ($sets as $set) {
-            if (!$set instanceof Query) {
+            if (($set instanceof Query) === false) {
                 continue;
             }
             $name = $set->getFieldName();
@@ -807,7 +807,8 @@ things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
                 )
             );
         }
-        self::assertEquals('query {
+        self::assertEquals(
+            'query {
 things {
 id
 name
@@ -818,6 +819,7 @@ someField
 someOtherField
 }
 }
-}', (string) $gql);
+}',
+            (string) $gql);
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -730,4 +730,71 @@ fragment_field2
 
         return $query;
     }
+
+    /**
+     * @covers \GraphQL\Query::getArguments
+     */
+    public function testGettingArguments()
+    {
+        $gql = (new Query('things'))
+            ->setArguments([
+                'someClientId' => 'someValueBasedOnCodebase'
+            ]);
+        $cursor_id = 'someCursor';
+        $new_args = $gql->getArguments();
+        $gql->setArguments(array_merge($new_args, [
+            'after' => $cursor_id
+        ]));
+        self::assertEquals('query {
+things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
+}', (string) $gql);
+    }
+
+    /**
+     * @covers \GraphQL\Query::getFieldName
+     */
+    public function testGettingNameAndAltering()
+    {
+        $gql = (new Query('things'))
+            ->setSelectionSet([
+                'id',
+                'name',
+                (new Query('subThings'))
+                    ->setArguments([
+                        'filter' => 'providerId123',
+                    ])
+                    ->setSelectionSet([
+                        'id',
+                        'name'
+                    ])
+            ]);
+        $sets = $gql->getSelectionSet();
+        $new_set = [];
+        foreach ($sets as $set) {
+            if (!$set instanceof Query) {
+                continue;
+            }
+            $name = $set->getFieldName();
+            if ($name !== 'subThings') {
+                continue;
+            }
+            $set->setArguments(['filter' => 'providerId456']);
+            $set->setSelectionSet(array_merge($set->getSelectionSet(), [
+                'someField',
+                'someOtherField'
+            ]));
+        }
+        self::assertEquals('query {
+things {
+id
+name
+subThings(filter: "providerId456") {
+id
+name
+someField
+someOtherField
+}
+}
+}', (string) $gql);
+    }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -766,20 +766,24 @@ things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
     public function testGettingNameAndAltering()
     {
         $gql = (new Query('things'))
-            ->setSelectionSet([
-                'id',
-                'name',
-                (new Query('subThings'))
-                    ->setArguments([
-                        'filter' => 'providerId123',
-                    ])
-                    ->setSelectionSet([
-                        'id',
-                        'name'
-                    ])
+            ->setSelectionSet(
+                [
+                    'id',
+                    'name',
+                    (new Query('subThings'))
+                        ->setArguments(
+                            [
+                                'filter' => 'providerId123',
+                            ]
+                        )
+                        ->setSelectionSet(
+                            [
+                                'id',
+                                'name'
+                            ]
+                        )
             ]);
         $sets = $gql->getSelectionSet();
-        $new_set = [];
         foreach ($sets as $set) {
             if (!$set instanceof Query) {
                 continue;
@@ -788,11 +792,20 @@ things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
             if ($name !== 'subThings') {
                 continue;
             }
-            $set->setArguments(['filter' => 'providerId456']);
-            $set->setSelectionSet(array_merge($set->getSelectionSet(), [
-                'someField',
-                'someOtherField'
-            ]));
+            $set->setArguments(
+                [
+                    'filter' => 'providerId456'
+                ]
+            );
+            $set->setSelectionSet(
+                array_merge(
+                    $set->getSelectionSet(),
+                    [
+                        'someField',
+                        'someOtherField'
+                    ]
+                )
+            );
         }
         self::assertEquals('query {
 things {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -737,17 +737,27 @@ fragment_field2
     public function testGettingArguments()
     {
         $gql = (new Query('things'))
-            ->setArguments([
-                'someClientId' => 'someValueBasedOnCodebase'
-            ]);
+            ->setArguments(
+                [
+                   'someClientId' => 'someValueBasedOnCodebase'
+                ]
+            );
         $cursor_id = 'someCursor';
         $new_args = $gql->getArguments();
-        $gql->setArguments(array_merge($new_args, [
-            'after' => $cursor_id
-        ]));
-        self::assertEquals('query {
+        $gql->setArguments(
+            array_merge(
+                $new_args,
+                [
+                    'after' => $cursor_id
+                ]
+            )
+        );
+        self::assertEquals(
+            'query {
 things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
-}', (string) $gql);
+}',
+            (string) $gql
+        );
     }
 
     /**


### PR DESCRIPTION
Thanks for this library. For me it's super important to represent the query as an object, and this library seems to do the trick nicely. However, it's missing 2 things I need, which this PR adds:

A getter for field name and a getter for arguments.

First. Here is a simple program to illustrate why I want a getter for arguments:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

$gql = (new \GraphQL\Query('things'))
  ->setArguments([
    'someClientId' => 'someValueBasedOnCodebase'
  ]);

echo (string) $gql;

// This prints:
// query {
//things(someClientId: "someValueBasedOnCodebase")
//}

// Response is queued and serialized and deserialized, and now all I have back
// is the query object and a cursor id, and I want to just append some arguments
// to it.
$cursor_id = 'someCursor';
$new_args = $gql->getArguments();
$gql->setArguments(array_merge($new_args, [
  'after' => $cursor_id
]));

echo (string) $gql;
// With this PR this prints:
// query {
//things(someClientId: "someValueBasedOnCodebase" after: "someCursor")
//}
```

And here is why I want the getter for field name:

```php
<?php

require_once __DIR__ . '/vendor/autoload.php';

$gql = (new \GraphQL\Query('things'))
  ->setSelectionSet([
    'id',
    'name',
    (new \GraphQL\Query('subThings'))
      ->setArguments([
        'filter' => 'providerId123',
      ])
      ->setSelectionSet([
        'id',
        'name'
      ])
  ]);

echo (string) $gql;
// This prints:
// query{
//  things {
//    id
//    name
//    subThings(filter: "providerId123") {
//      id
//      name
//    }
//  }
//}

// Well that's all good. But what if I have 20 customers, and they all use the
// library I wrote to retrieve "things", but they have maybe different provider
// ids, and maybe even different fields they want to select. How about doing it
// like this in just a custom override for those where I need it:

$sets = $gql->getSelectionSet();
foreach ($sets as $set) {
  if (!$set instanceof \GraphQL\Query) {
    continue;
  }
  $name = $set->getFieldName();
  if ($name !== 'subThings') {
    continue;
  }
  $set->setArguments(['filter' => 'providerId456']);
  $set->setSelectionSet(array_merge($set->getSelectionSet(), [
    'someField',
    'someOtherField'
  ]));
}

echo (string) $gql;
// With this PR applied, this now is possible and prints:
// query {
//  things {
//    id
//    name
//    subThings(filter: "providerId456") {
//      id
//      name
//      someField
//      someOtherField
//    }
//  }
//}
```