### PR TITLE
Improve return types for QueryBuilder methods

### DIFF
--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -16,7 +16,7 @@ class QueryBuilder extends AbstractQueryBuilder
      *
      * @param Query|QueryBuilder|string $selectedField
      *
-     * @return AbstractQueryBuilder|QueryBuilder
+     * @return $this
      */
     public function selectField($selectedField)
     {
@@ -29,7 +29,7 @@ class QueryBuilder extends AbstractQueryBuilder
      * @param string $argumentName
      * @param        $argumentValue
      *
-     * @return AbstractQueryBuilder|QueryBuilder
+     * @return $this
      */
     public function setArgument(string $argumentName, $argumentValue)
     {
@@ -44,7 +44,7 @@ class QueryBuilder extends AbstractQueryBuilder
      * @param bool   $isRequired
      * @param null   $defaultValue
      *
-     * @return AbstractQueryBuilder|QueryBuilder
+     * @return $this
      */
     public function setVariable(string $name, string $type, bool $isRequired = false, $defaultValue = null)
     {


### PR DESCRIPTION
When I tried to chain select fields like

```php
(new QueryBuilder('node'))
    ->selectField('Id')
    ->selectField((new QueryBuilder('Bearer_Token__c'))->selectField('value'))
    ->selectField((new QueryBuilder('Webhook_Endpoint__c'))->selectField('value'))
```

PHPStan was giving me errors, because `selectField` isn't accessible on AbstractQueryBuilder.

This commit fixes that.