### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -65,9 +65,9 @@ class Client
         string $endpointUrl,
         array $authorizationHeaders = [],
         array $httpOptions = [],
-        ClientInterface $httpClient = null,
+        ?ClientInterface $httpClient = null,
         string $requestMethod = 'POST',
-        AuthInterface $auth = null
+        ?AuthInterface $auth = null
     ) {
         $headers = array_merge(
             $authorizationHeaders,


### PR DESCRIPTION
### What / Why
Fix PHP 8.4 deprecation warnings:

```
php-graphql-client/src/Client.php:64
GraphQL\Client::__construct(): Implicitly marking parameter $httpClient as nullable is deprecated, the explicit nullable type must be used instead

php-graphql-client/src/Client.php:0
GraphQL\Client::__construct(): Implicitly marking parameter $auth as nullable is deprecated, the explicit nullable type must be used instead
```

In PHP 8.4 and above, nullable arguments need to be explicitly marked as such when providing a typehint. This can either be done by using the ? operator or by add "null" to the typehint through a union type. This PR addresses this, fixing deprecation warnings emitted by PHP 8.4.

See: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated